### PR TITLE
orasw-meta: added OPatch for 19c

### DIFF
--- a/roles/orasw-meta/defaults/main.yml
+++ b/roles/orasw-meta/defaults/main.yml
@@ -56,6 +56,7 @@ oracle_sw_patches:
 
 
 oracle_opatch_patch:
+     - { filename: p6880880_190000_Linux-x86-64.zip, version: 19.3.0.0 }
      - { filename: p6880880_180000_Linux-x86-64.zip, version: 18.3.0.0 }
      - { filename: p6880880_122010_Linux-x86-64.zip, version: 12.2.0.1 }
      - { filename: p6880880_122010_Linux-x86-64.zip, version: 12.1.0.2 }


### PR DESCRIPTION
The filename for OPatch was missing in oracle_opatch_patch.