### PR TITLE
Fix systemd startscript and ansible 2.9 compatibility

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -5,7 +5,7 @@
     assert:
       that:
         - "ansible_os_family == '{{ os_family_supported }}'"
-        - "ansible_distribution_version | version_compare('{{ os_min_supported_version }}', '>=')"
+        - "ansible_distribution_version is version_compare('{{ os_min_supported_version }}', '>=')"
     tags:
      - oscheck
 

--- a/roles/oraswdb-install/files/manage_oracle_rdbms_procs.sh
+++ b/roles/oraswdb-install/files/manage_oracle_rdbms_procs.sh
@@ -124,7 +124,7 @@ function start_database() {
 
     fi
 
-    if [ ${STARTDB:-"N" = "Y" } ] ; then
+    if [ ${STARTDB:-"N"} = "Y" ] ; then
 
         # Using RMAN for startup
         # => easy to switch from mount to open for running instance during execution

--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -47,7 +47,7 @@
 # test -f => reduce number of executions when > 1 database in oracle_databases for same ORACLE_HOME
 # we cannot use default/main.yml here. => complicated structure for 'enabled' 'disabled'...
 - name: install-home-db | Change Database options with chopt
-  shell: "test -f {{ oracle_home_db }}/install/{{ item.state | replace(true, 'enable') | replace(false, 'disable') }}_{{item.option}}.log || {{ oracle_home_db }}/bin/chopt {{ item.state | replace(true, 'enable') | replace(false, 'disable') }} {{item.option}}"
+  shell: "test $(ls {{ oracle_home_db }}/install/{{ item.state | replace(true, 'enable') | replace(false, 'disable') }}_{{item.option}}*.log | wc -l) -gt 0 || {{ oracle_home_db }}/bin/chopt {{ item.state | replace(true, 'enable') | replace(false, 'disable') }} {{item.option}}"
   with_items:
     - "{{oracle_EE_options}}"
   become: yes


### PR DESCRIPTION
Fixes an error in systemd start script that caused it to start also databases marked :N in oratab.
In addition, a small syntax fix, that makes it work with ansible version 2.9 and above