### PR TITLE
orahost: added resizefs=yes

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -216,7 +216,7 @@
     tags: hostfs
 
   - name: filesystem | create lv
-    lvol: vg={{ item.0.vgname }} lv={{ item.1.lvname }} size={{ item.1.lvsize }} state=present shrink=no
+    lvol: vg={{ item.0.vgname }} lv={{ item.1.lvname }} size={{ item.1.lvsize }} state=present shrink=no resizefs=yes
     with_subelements:
         - "{{host_fs_layout}}"
         - filesystem


### PR DESCRIPTION
lvsize in host_fs_layout did not change the lvol with underlying
Filesystem.
This has been change by adding resizefs=yes to the lvol task.