### PR TITLE
changed minimum Ansible version to 2.8

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,6 +17,10 @@
 #     - "~/.ssh/authorized_keys"
 #    tags:
 #     - keys
+  - name: Check for correct Ansible Version (>= 2.8)
+    assert:
+      that:
+        - "ansible_version.full is version('2.8', '>=')"
 
   - name: Install EPEL Repo
     yum: name={{ epel_rpm }} state=installed
@@ -48,8 +52,7 @@
       - commonpackages
 
   - name: Install common packages SLES12
-    zypper: name={{ item }} state=installed
-    with_items: "{{ common_packages_sles }}"
+    zypper: name={{ common_packages_sles }} state=installed
     when: install_os_packages and ansible_os_family == 'Suse'
     tags:
       - commonpackages

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -5,7 +5,7 @@
     assert:
       that:
         - "ansible_os_family == '{{ os_family_supported }}'"
-        - "ansible_distribution_version | version_compare('{{ os_min_supported_version }}', '>=')"
+        - "ansible_facts['distribution_version'] is version('{{ os_min_supported_version }}', '>=')"
     tags:
      - oscheck
 
@@ -19,8 +19,7 @@
     tags: os_packages, oscheck
 
   - name: Install packages required by Oracle on SLES
-    zypper: name={{ item }} state=installed
-    with_items: "{{ oracle_packages_sles }}"
+    zypper: name={{ oracle_packages_sles }} state=installed
     when: install_os_packages and ansible_os_family == 'Suse'
     tags: os_packages, oscheck
 
@@ -34,8 +33,7 @@
     tags: os_packages, oscheck
 
   - name: Install packages required by Oracle for ASMlib on SLES
-    zypper: name={{ item }} state=installed
-    with_items: "{{ oracle_asm_packages_sles }}"
+    zypper: name={{ oracle_asm_packages_sles }} state=installed
     when: install_os_packages and device_persistence == 'asmlib' and ansible_os_family == 'Suse' and asm_diskgroups is defined
     tags: os_packages, oscheck, asm1
 

--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -79,7 +79,7 @@
   become: yes
   become_user: "{{ oracle_user }}"
   run_once: "{{ configure_cluster}}"
-  when: oradbinstall
+  when: oradbinstall is defined
   changed_when: False
   register: opatchls
   tags:


### PR DESCRIPTION
It is time to move to a much newer version of Ansible, due to desupport of really old used versions of Ansible for developing this project.

The new minimum version is 2.8 and this PR is tested against 2.8 and 2.9.