### PR TITLE
orahost: Added support for timezone change

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -65,6 +65,25 @@
     register: disable_selinux_runtime
     tags: selinux
 
+  - block:
+    - name: Set Timezone
+      timezone:
+        name: "{{ os_timezone }}"
+        hwclock: "{{ os_hwclock | default(omit) }}"
+      register: timezoneresult
+      tags: timezone
+
+    - name: Restart crond after timezone change
+      service:
+        name: crond
+        state: restarted
+      when: 
+        - timezoneresult is defined
+        - timezoneresult.changed
+      tags: timezone
+
+    when: os_timezone is defined
+
   - name: Check dns for host
     command: host {{ ansible_hostname }}
     register: ns


### PR DESCRIPTION
The following variables have been added:

- os_timezone: <not defined by default>
- os_hwclock: <ignored by default>

Example:

os_timezone: Europe/Berlin