### PR TITLE
orahost: new approach for setting hugepages during setup

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -258,8 +258,28 @@
   - name: Oracle hugepages
     sysctl: name={{ item.name }} value="{{ item.value }}" state=present reload=yes ignoreerrors=yes
     with_items: "{{oracle_hugepages}}"
+    register: systclcmd
     tags: sysctl,hugepages
 
+  # There is no safe way to allocate Hugepages in a running system.
+  # => A reboot should be done after changing the configuration
+  # => we won't reboot during installation
+  # Work Arroud:
+  # => Flush File Cache
+  # => retry a sysctl -p
+  - block:
+    - name: Flush Buffer Cache when hugepages have been changed
+      command: echo 2 > /proc/sys/vm/drop_caches
+      tags: sysctl,hugepages
+
+    - name: Try sysctl again
+      sysctl: name={{ item.name }} value="{{ item.value }}" state=present reload=yes
+      with_items: "{{oracle_hugepages}}"
+      tags: sysctl,hugepages
+    when:
+      - systclcmd is defined
+      - systclcmd.changed
+    tags: sysctl,hugepages
 
   - name: Oracle-recommended PAM config
     lineinfile: dest=/etc/pam.d/login state=present line="session required pam_limits.so"


### PR DESCRIPTION
Some Kernels do not allow an increase of hugepages without
enough free memory. When hugepages could not be allocated
during initial setup the execution of DBCA could fail due
to missing enough hugpages.

When vm.nr_hugepages is changed the filecache is flushed
and anoher execution of systcl -p is done - hopefully to
allocate the needed pages.