### PR TITLE
Create Golden-Images for Oracle Restart and Database-Homes

### DIFF
--- a/roles/orasw-meta/defaults/main.yml
+++ b/roles/orasw-meta/defaults/main.yml
@@ -114,3 +114,7 @@ db_version: "{%- if dbh is defined and db_homes_config[dbh.home] is defined -%}
                       {{db_homes_config[item.home]['version']}}
                  {%- endif -%}
              {%- endif -%}"
+
+oracle_home_gi: "{% if configure_cluster %}{{ oracle_home_gi_cl }}{% else %}{{ oracle_home_gi_so }}{% endif %}"
+oracle_home_gi_cl: "/u01/app/{{ oracle_install_version_gi }}/grid" # ORACLE_HOME for Grid Infrastructure (Clustered)
+oracle_home_gi_so: "{{ oracle_base }}/{{ oracle_install_version_gi }}/grid" # ORACLE_HOME for Grid Infrastructure (Stand Alone)

--- a/roles/oraswdb-golden-image/meta/main.yml
+++ b/roles/oraswdb-golden-image/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: orasw-meta }

--- a/roles/oraswdb-golden-image/tasks/main.yml
+++ b/roles/oraswdb-golden-image/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- assert:
+    that: golden_image_dest is defined
+
+- block:
+
+  - name: Create destination directory for Golden-Image
+    file:
+      path: "{{ golden_image_dest }}/{{ dbh.home}}"
+      state: directory
+      mode: '0755'
+    with_items:
+      - "{{ db_homes_installed | unique }}"
+    loop_control:
+      label: "{{ golden_image_dest }}/{{ dbh.home | default('') }}"
+      loop_var: dbh
+    when:
+      - "db_version is version('18', '>=')"
+
+  - name: Create Golden-Image
+    command: "{{ oracle_home_db }}/runInstaller -silent -createGoldImage -destinationLocation {{ golden_image_dest }}/{{ dbh.home}}"
+    with_items:
+      - "{{ db_homes_installed | unique }}"
+    loop_control:
+      label: "{{ oracle_home_db | default('') }}"
+      loop_var: dbh
+    when:
+      - "db_version is version('18', '>=')"
+    register: createimage
+
+  - debug: msg="{{ item.stdout_lines }}"
+    with_items:
+      - "{{ createimage.results }}"
+    loop_control:
+      label: ""
+    when: createimage.results is defined
+
+  become: yes
+  become_user: "{{ oracle_user }}"
+  when:
+    - db_homes_installed is defined

--- a/roles/oraswgi-golden-image/meta/main.yml
+++ b/roles/oraswgi-golden-image/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: orasw-meta }

--- a/roles/oraswgi-golden-image/tasks/main.yml
+++ b/roles/oraswgi-golden-image/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- assert:
+    that: golden_image_dest is defined
+
+# Creating Oracle Restart Golden-Image requires a running stack under 19c
+- block:
+  - name: Check for running Oracle Restart when installed
+    command: "{{ oracle_home_gi }}/bin/crsctl status server"
+    register: crscheck
+
+  - debug: msg="{{ crscheck.stdout_lines }}"
+    when: crscheck.stdout_lines is defined
+
+  - name: Create destination directory {{ golden_image_dest }} for Golden-Image
+    file:
+      path: "{{ golden_image_dest }}"
+      state: directory
+      mode: '0755'
+
+  - name: Create Golden-Image
+    command: "{{ oracle_home_gi }}/gridSetup.sh -silent -createGoldImage -destinationLocation {{ golden_image_dest }}"
+    register: createimage
+
+  - debug: msg="{{ createimage.stdout_lines }}"
+    when: createimage.stdout_lines is defined
+
+  become: yes
+  become_user: "{{ oracle_user }}"
+  when:
+    - oracle_home_gi is defined


### PR DESCRIPTION
The role uses `gridSetup.sh -silent -createGoldImage -destinationLocation`
to create Golden Images from running installations.

The following variable must be set:
  `golden_image_dest: /u01/golden`

The directroy is created by oracle.