### PR TITLE
oraswdb-manage-patches: Extension for UPI (Unique Patch ID)

### DIFF
--- a/library/oracle_opatch
+++ b/library/oracle_opatch
@@ -37,6 +37,15 @@ options:
         required: False
         default: None
         aliases: ['version_added']
+    exclude_upi:
+        description:
+            - The unique patch identifier that should not be rolled back
+              e.g 22990084
+            - This option will be honored only when state=absent.
+            - It helps to write idempotent playbooks when changing interim patches that are dependent on a specific PSU/RU.
+        required: False
+        default: None
+        aliases: ['exclude_unique_patch_id']
     opatch_minversion:
         description:
             - The minimum version of opatch needed
@@ -155,7 +164,7 @@ def get_file_owner(module, msg, oracle_home):
         msg = 'Could not determine owner of %s ' % (checkfile)
         module.fail_json(msg=msg)
 
-def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, exclude_upi):
     '''
     Gets all patches already applied and compares to the
     intended patch
@@ -169,8 +178,8 @@ def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatc
     (rc, stdout, stderr) = module.run_command(command)
     #module.exit_json(msg=stdout, changed=False)
     if rc != 0:
-      msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
-      module.fail_json(msg=msg, changed=False)
+        msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+        module.fail_json(msg=msg, changed=False)
     else:
         if opatchauto:
             chk = '%s' % (patch_version)
@@ -180,7 +189,17 @@ def check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatc
             chk = '%s' % (patch_id)
 
         if chk in stdout:
-            return True
+            if exclude_upi is None:
+                return True
+            else:
+                command += ' -id %s' % patch_id
+                (rc, stdout, stderr) = module.run_command(command)
+                if rc != 0:
+                    msg = 'Error - STDOUT: %s, STDERR: %s, COMMAND: %s' % (stdout, stderr, command)
+                    module.fail_json(msg=msg, changed=False)
+                else:
+                    chk = 'unique_patch_id:%s' % exclude_upi
+                    return (chk not in stdout)
         else:
             return False
 
@@ -450,6 +469,7 @@ def main():
             patch_base          = dict(default=None, aliases = ['path','source','patch_source','phBaseDir']),
             patch_id            = dict(default=None, aliases = ['id']),
             patch_version       = dict(required=None, aliases = ['version']),
+            exclude_upi         = dict(required=None, aliases = ['exclude_unique_patch_id']),
             opatch_minversion   = dict(default=None, aliases = ['opmv']),
             opatchauto          = dict(default='False', type='bool',aliases = ['autopatch']),
             rolling             = dict(default='True', type='bool',aliases = ['rolling']),
@@ -461,7 +481,7 @@ def main():
             output              = dict(default="short", choices = ["short","verbose"]),
             state               = dict(default="present", choices = ["present", "absent", "opatchversion"]),
             hostname            = dict(required=False, default = 'localhost', aliases = ['host']),
-            port                = dict(required=False, default = 1521),
+            port                = dict(required=False, type='int', default = 1521),
 
 
 
@@ -473,6 +493,7 @@ def main():
     patch_base          = module.params["patch_base"]
     patch_id            = module.params["patch_id"]
     patch_version       = module.params["patch_version"]
+    exclude_upi         = module.params["exclude_upi"]
     opatch_minversion   = module.params["opatch_minversion"]
     opatchauto          = module.params["opatchauto"]
     rolling             = module.params["rolling"]
@@ -533,7 +554,7 @@ def main():
         module.exit_json(msg=opatch_version,changed=False)
 
     if state == 'present':
-        if not check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+        if not check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, None):
             if apply_patch(module, msg, oracle_home, patch_base, patch_id,patch_version, opatchauto,ocm_response_file,offline,stop_processes,rolling,output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully applied to %s' % (patch_id,patch_version, oracle_home)
@@ -549,7 +570,7 @@ def main():
             module.exit_json(msg=msg, changed=False)
 
     elif state == 'absent':
-        if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
+        if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto, exclude_upi):
             if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, stop_processes, output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully removed from %s' % (patch_id,patch_version, oracle_home)
@@ -560,8 +581,9 @@ def main():
                 module.fail_json(msg=msg, changed=False)
         else:
             if patch_version is not None:
-                msg = 'Patch %s (%s) is not applied to %s' % (patch_id,patch_version, oracle_home)
-
+                msg = 'Patch %s (%s) is not applied to %s' % (patch_id, patch_version, oracle_home)
+            elif exclude_upi is not None:
+                msg = 'Patch %s (UPI %s) has already been applied and will not be removed from %s' % (patch_id, exclude_upi, oracle_home)
             else:
                 msg = 'Patch %s is not applied to %s' % (patch_id, oracle_home)
 

--- a/library/oracle_opatch
+++ b/library/oracle_opatch
@@ -341,7 +341,7 @@ def stop_process(module, oracle_home):
                    if msg:
                        module.fail_json(msg=msg, changed=False)
 
-def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, ocm_response_file,output):
+def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, ocm_response_file, stop_processes, output):
     '''
     Removes the patch
     '''
@@ -354,6 +354,9 @@ def remove_patch (module, msg, oracle_home, patch_base, patch_id, opatchauto, oc
 
         command = '%s/OPatch/%s %s -oh %s ' % (oracle_home,opatch_cmd, patch_base, oracle_home)
     else:
+        if stop_processes:
+            stop_process(module, oracle_home)
+
         opatch_cmd = 'opatch rollback'
         command = '%s/OPatch/%s -id %s -silent' % (oracle_home,opatch_cmd, patch_id)
 
@@ -547,7 +550,7 @@ def main():
 
     elif state == 'absent':
         if check_patch_applied(module, msg, oracle_home, patch_id, patch_version, opatchauto):
-            if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, output):
+            if remove_patch(module, msg, oracle_home, patch_base, patch_id, opatchauto,ocm_response_file, stop_processes, output):
                 if patch_version is not None:
                     msg = 'Patch %s (%s) successfully removed from %s' % (patch_id,patch_version, oracle_home)
                 else:

--- a/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
+++ b/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
@@ -112,6 +112,7 @@
       patch_base={{ oracle_patch_install }}/{{ db_version}}/{{ item.path | default (item.patchid)}}/
       patch_id={{item.patchid}}
       patch_version={{ item.patchversion |default(omit)}}
+      exclude_upi={{ item.excludeUPI | default(omit)}}
       opatchauto=False
       conflict_check=True
       stop_processes={{item.stop_processes |default(False)}}

--- a/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
+++ b/roles/oraswdb-manage-patches/tasks/db-home-patch.yml
@@ -44,6 +44,7 @@
       patch_base={{ oracle_patch_install }}/{{ db_version}}/{{ item.path | default (item.patchid)}}/
       patch_id={{item.patchid}}
       patch_version={{ item.patchversion |default(omit)}}
+      exclude_upi={{ item.excludeUPI | default(omit)}}
       opatchauto=False
       conflict_check=True
       stop_processes={{item.stop_processes |default(False)}}

--- a/roles/oraswdb-manage-patches/tasks/transfer-files.yml
+++ b/roles/oraswdb-manage-patches/tasks/transfer-files.yml
@@ -1,4 +1,4 @@
-- name: gi-opatch | Copy oracle GI patch (opatchauto) to server (www)
+- name: db-opatch | Copy oracle DB patch (opatchauto) to server (www)
   get_url:
       url={{ oracle_sw_source_www }}/{{ item[0].filename }}
       dest={{ oracle_stage }}
@@ -12,7 +12,7 @@
   tags:
     - oragridpatchget
 
-- name: gi-opatch | Copy oracle GI patch (opatchauto) to server (local)
+- name: db-opatch | Copy oracle DB patch (opatchauto) to server (local)
   copy:
      src={{ oracle_sw_source_local }}/{{ item[0].filename }}
      dest={{ oracle_stage }}
@@ -27,7 +27,46 @@
   tags:
   - oragridpatchpush
 
-- name: gi-opatch | Copy oracle opatch to server (www)
+- name: db-opatch | Copy oracle DB patch (opatch) to server (www)
+  get_url:
+      url={{ oracle_sw_source_www }}/{{ item[0].filename }}
+      dest={{ oracle_stage }}/{{ item[0].filename }}
+      mode=775
+  with_nested:
+     - "{{oracle_sw_patches}}"
+     - "{{db_homes_config[dbh.home]['opatch']}}"
+  when:
+    - apply_patches_db
+    - item[1].patchid == item[0].patchid
+    - ( item[0].upi is not defined or item[1].upi is not defined or item[0].upi == item[1].upi )
+    - item[1].state == "present"
+    - oracle_sw_copy and not is_sw_source_local
+  become: yes
+  become_user: "{{ oracle_user }}"
+  tags:
+    - oragridpatchget
+
+- name: db-opatch | Copy oracle DB patch (opatch) to server (local)
+  copy:
+     src={{ oracle_sw_source_local }}/{{ item[0].filename }}
+     dest={{ oracle_stage }}/{{ item[0].filename }}
+     mode=775
+     force=no
+  with_nested:
+  - "{{oracle_sw_patches}}"
+  - "{{db_homes_config[dbh.home]['opatch']}}"
+  when:
+    - apply_patches_db
+    - item[1].patchid == item[0].patchid
+    - ( item[0].upi is not defined or item[1].upi is not defined or item[0].upi == item[1].upi )
+    - item[1].state == "present"
+    - oracle_sw_copy and is_sw_source_local
+  become: yes
+  become_user: "{{ oracle_user }}"
+  tags:
+  - oragridpatchpush
+
+- name: db-opatch | Copy oracle opatch to server (www)
   get_url:
       url={{ oracle_sw_source_www }}/{{ item.filename }}
       dest={{ oracle_stage }}
@@ -40,7 +79,7 @@
   tags:
     - oragridopatchget
 
-- name: gi-opatch | Copy oracle opatch to server (local)
+- name: db-opatch | Copy oracle opatch to server (local)
   copy:
      src={{ oracle_sw_source_local }}/{{ item.filename }}
      dest={{ oracle_stage }}

--- a/roles/oraswdb-manage-patches/tasks/unpack-files.yml
+++ b/roles/oraswdb-manage-patches/tasks/unpack-files.yml
@@ -41,7 +41,13 @@
   with_nested:
      - "{{oracle_sw_patches}}"
      - "{{db_homes_config[dbh.home]['opatch']}}"
-  when: apply_patches_db and item[1].patchid == item[0].patchid and item[1].state == 'present' and oracle_sw_copy and oracle_sw_unpack and db_homes_config[dbh.home]['opatch'] is defined
+  when:
+    - apply_patches_db
+    - item[1].patchid == item[0].patchid
+    - ( item[0].upi is not defined or item[1].upi is not defined or item[0].upi == item[1].upi )
+    - item[1].state == 'present'
+    - oracle_sw_copy and oracle_sw_unpack
+    - db_homes_config[dbh.home]['opatch'] is defined
   tags:
     - oraswdbpsuunpack1
 
@@ -56,6 +62,12 @@
   with_nested:
      - "{{oracle_sw_patches}}"
      - "{{db_homes_config[dbh.home]['opatch']}}"
-  when: apply_patches_db and item[1].patchid == item[0].patchid and item[1].state == 'present' and not oracle_sw_copy and oracle_sw_unpack and db_homes_config[dbh.home]['opatch'] is defined
+  when:
+    - apply_patches_db
+    - item[1].patchid == item[0].patchid
+    - ( item[0].upi is not defined or item[1].upi is not defined or item[0].upi == item[1].upi )
+    - item[1].state == 'present'
+    - not oracle_sw_copy and oracle_sw_unpack
+    - db_homes_config[dbh.home]['opatch'] is defined
   tags:
     - oraswdbpsuunpack2


### PR DESCRIPTION
Some interim patches are PSU/RU dependent. The patch ID is the same
but content, dependencies, and UPI (unique patch ID) differ. These
patches have to be rolled back in advance of applying the PSU/RU and
must afterwards be installed with the correct version (=UPI). If
{{oracle_sw_patches}} contains the files from different UPIs of the
same patch the right one has to be transferred and unpacked.

Usage is like this:

```
db_homes_config:
  12.1.0.2-ee:
    ### DB PSU Jul 2019
    opatch_minversion: 12.2.0.1.17
    opatch:
      - { patchid: 21238475, state: absent, stop_processes: True }
      - { patchid: 18633374, state: absent, excludeUPI: 22990084, stop_processes: True }
      - { patchid: 29494060, state: present, stop_processes: True } # PSU
      - { patchid: 18881811, state: present, stop_processes: True }
      - { patchid: 18633374, state: present, upi: 22990084, stop_processes: True }

oracle_sw_patches:
  - patchid: 29494060
    version: 12.1.0.2
    patchversion: 12.1.0.2.190716
    description: DB-PSU-Jul-2019
    filename: p29494060_121020_Linux-x86-64.zip
    creates: 29494060/27547329/files/ctx/admin/dr0ddl.pkh
  - patchid: 18633374
    upi: 22629069
    filename: patches/12.1.0.2/p18633374_12102190115_Linux-x86-64.zip
  - patchid: 18633374
    upi: 22990084
    filename: patches/12.1.0.2/p18633374_12102190716_Linux-x86-64.zip
  - patchid: 18881811
    filename: patches/12.1.0.2/p18881811_121020_Generic.zip

```