### PR TITLE
orahost: Bugfix for factor_os is undefined

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -19,7 +19,7 @@
     when: 
       - install_os_packages
       - ansible_os_family == 'RedHat'
-      - facter_os.release.major is version('7', '<=')
+      - ansible_distribution_major_version is version('7', '<=')
     tags: os_packages, oscheck
 
   - name: Install packages required by Oracle on SLES


### PR DESCRIPTION
We cannot use factor_os so early in orahost, due to missing facter.rpm.