### PR TITLE
oraswgi-install: Fixes for RAC-Setups

### DIFF
--- a/roles/oraswgi-install/tasks/12.2.0.1.yml
+++ b/roles/oraswgi-install/tasks/12.2.0.1.yml
@@ -10,6 +10,7 @@
     creates: "{{ oracle_home_gi }}/root.sh"
   become: true
   become_user: "{{ grid_install_user }}"
+  run_once: "{{ configure_cluster }}"
   tags:
     - oragridswunpack
   when: oracle_home_gi not in checkgiinstall.stdout and oracle_install_version_gi == item.version and oracle_sw_copy and oracle_sw_unpack
@@ -31,7 +32,6 @@
   stat: path={{ oracle_home_gi }}/gridSetup.sh
   register: stat_gridsetup_result
   run_once: "{{ configure_cluster }}"
-  # when: master_node
 
 - name: install-home-gi | State of GridSetup.sh
   assert:

--- a/roles/oraswgi-install/tasks/18.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/18.3.0.0.yml
@@ -7,6 +7,7 @@
     creates: "{{ oracle_home_gi }}/root.sh"
   become: true
   become_user: "{{ grid_install_user }}"
+  run_once: "{{ configure_cluster }}"
   tags:
     - oragridswunpack
   when: oracle_home_gi not in checkgiinstall.stdout and oracle_install_version_gi == item.version and oracle_sw_copy and oracle_sw_unpack
@@ -18,6 +19,7 @@
     creates: "{{ oracle_home_gi }}/root.sh"
   become: true
   become_user: "{{ grid_install_user }}"
+  run_once: "{{ configure_cluster }}"
   tags:
     - oragridswunpack
   when: oracle_home_gi not in checkgiinstall.stdout and oracle_install_version_gi == item.version and not oracle_sw_copy
@@ -28,7 +30,6 @@
   stat: path={{ oracle_home_gi }}/gridSetup.sh
   register: stat_gridsetup_result
   run_once: "{{ configure_cluster }}"
-  # when: master_node
 
 - name: install-home-gi | State of GridSetup.sh
   assert:

--- a/roles/oraswgi-install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/19.3.0.0.yml
@@ -9,6 +9,7 @@
     creates: "{{ oracle_home_gi }}/root.sh"
   become: true
   become_user: "{{ grid_install_user }}"
+  run_once: "{{ configure_cluster }}"
   tags:
     - oragridswunpack
   when:
@@ -21,14 +22,13 @@
   stat: path={{ oracle_home_gi }}/gridSetup.sh
   register: stat_gridsetup_result
   run_once: "{{ configure_cluster }}"
-  # when: master_node
 
 - name: install-home-gi | State of GridSetup.sh
   assert:
     that: "stat_gridsetup_result.stat.exists == True"
     msg: "Cannot find {{ oracle_home_gi }}/gridSetup.sh }}"
   run_once: "{{ configure_cluster }}"
-  # when: master_node
+
 # unarchive didn't worked in some environments. => using unzip directly
 # Overwrite existing files from OPatch due to Note 2321749.1
 # - name: install-home-gi | Distribute latest opatch

--- a/roles/oraswgi-install/tasks/21.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/21.3.0.0.yml
@@ -9,6 +9,7 @@
     creates: "{{ oracle_home_gi }}/root.sh"
   become: true
   become_user: "{{ grid_install_user }}"
+  run_once: "{{ configure_cluster }}"
   tags:
     - oragridswunpack
   when:
@@ -21,14 +22,12 @@
   stat: path={{ oracle_home_gi }}/gridSetup.sh
   register: stat_gridsetup_result
   run_once: "{{ configure_cluster }}"
-  # when: master_node
 
 - name: install-home-gi | State of GridSetup.sh
   assert:
     that: "stat_gridsetup_result.stat.exists == True"
     msg: "Cannot find {{ oracle_home_gi }}/gridSetup.sh }}"
   run_once: "{{ configure_cluster }}"
-  # when: master_node
 
 - name: install-home-gi | Install cvuqdisk rpm
   yum: name="{{ oracle_home_gi }}/cv/rpm/{{ cvuqdisk_rpm }}" state=present

--- a/roles/oraswgi-install/tasks/main.yml
+++ b/roles/oraswgi-install/tasks/main.yml
@@ -6,6 +6,7 @@
   # noqa command-instead-of-shell risky-shell-pipe
   tags:
     - checkifgiinstall
+    - responsefilegi
   changed_when: false
   register: checkgiinstall
 
@@ -70,6 +71,7 @@
 
 - name: include_tasks "{{ oracle_install_version_gi }}.yml"
   include_tasks: "{{ oracle_install_version_gi }}.yml"
+  tags: always
 
 - name: install-home-gi | Check if stuff is running
   shell: "{{ oracle_home_gi }}/bin/crsctl stat res -t"

--- a/roles/oraswgi-install/templates/grid-install.rsp.12.2.0.1.j2
+++ b/roles/oraswgi-install/templates/grid-install.rsp.12.2.0.1.j2
@@ -245,24 +245,24 @@ oracle.install.crs.config.sites=
 # hostnameprefix:lowerbound-upperbound:hostnamesuffix:vipsuffix:role of node
 #
 #-------------------------------------------------------------------------------
-{%  if oracle_gi_cluster_type|upper  == "STANDARD"  or oracle_gi_cluster_type|upper == 'STANDALONE' %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-  {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-{% endif %}
-
-{% elif oracle_gi_cluster_type|upper == 'FLEX'  %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
- {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}.{{ ansible_domain }}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
-
- {% endif %}
-
-{% endif %}
+oracle.install.crs.config.clusterNodes=
+{%- if configure_cluster -%}
+  {%- for host in groups[hostgroup] -%} {{ hostvars[host].ansible_fqdn }}:
+    {%- if hostvars[host].oracle_node_vip is defined -%}
+      {{ hostvars[host].oracle_node_vip }}
+    {%- else -%}
+      {{ hostvars[host].ansible_hostname }}{{ oracle_vip }}
+      {%- if hostvars[host].ansible_domain | length > 0 -%}
+        .{{ hostvars[host].ansible_domain }}
+      {%- endif -%}
+    {%- endif -%}
+    {% if oracle_gi_cluster_type | upper == 'FLEX' -%}
+      :HUB
+    {%- endif -%}
+    {%- if not loop.last -%},
+    {%- endif -%} 
+  {%- endfor %}
+{%- endif %}
 
 #-------------------------------------------------------------------------------
 # The value should be a comma separated strings where each string is as shown below

--- a/roles/oraswgi-install/templates/grid-install.rsp.18.3.0.0.j2
+++ b/roles/oraswgi-install/templates/grid-install.rsp.18.3.0.0.j2
@@ -262,25 +262,24 @@ oracle.install.crs.config.sites=
 # hostnameprefix:lowerbound-upperbound:hostnamesuffix:vipsuffix:role of node
 #
 #-------------------------------------------------------------------------------
-{%  if oracle_gi_cluster_type|upper  == "STANDARD"  or oracle_gi_cluster_type|upper == 'STANDALONE' %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-  {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-{% endif %}
-
-{% elif oracle_gi_cluster_type|upper == 'FLEX'  %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
- {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}.{{ ansible_domain }}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
-
- {% endif %}
-
-{% endif %}
-
+oracle.install.crs.config.clusterNodes=
+{%- if configure_cluster -%}
+  {%- for host in groups[hostgroup] -%} {{ hostvars[host].ansible_fqdn }}:
+    {%- if hostvars[host].oracle_node_vip is defined -%}
+      {{ hostvars[host].oracle_node_vip }}
+    {%- else -%}
+      {{ hostvars[host].ansible_hostname }}{{ oracle_vip }}
+      {%- if hostvars[host].ansible_domain | length > 0 -%}
+        .{{ hostvars[host].ansible_domain }}
+      {%- endif -%}
+    {%- endif -%}
+    {% if oracle_gi_cluster_type | upper == 'FLEX' -%}
+      :HUB
+    {%- endif -%}
+    {%- if not loop.last -%},
+    {%- endif -%} 
+  {%- endfor %}
+{%- endif %}
 
 #-------------------------------------------------------------------------------
 # The value should be a comma separated strings where each string is as shown below

--- a/roles/oraswgi-install/templates/grid-install.rsp.19.3.0.0.j2
+++ b/roles/oraswgi-install/templates/grid-install.rsp.19.3.0.0.j2
@@ -257,25 +257,24 @@ oracle.install.crs.config.sites=
 # hostnameprefix:lowerbound-upperbound:hostnamesuffix:vipsuffix:role of node
 #
 #-------------------------------------------------------------------------------
-{%  if oracle_gi_cluster_type|upper  == "STANDARD"  or oracle_gi_cluster_type|upper == 'STANDALONE' %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-  {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-{% endif %}
-
-{% elif oracle_gi_cluster_type|upper == 'FLEX'  %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
- {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}.{{ ansible_domain }}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
-
- {% endif %}
-
-{% endif %}
-
+oracle.install.crs.config.clusterNodes=
+{%- if configure_cluster -%}
+  {%- for host in groups[hostgroup] -%} {{ hostvars[host].ansible_fqdn }}:
+    {%- if hostvars[host].oracle_node_vip is defined -%}
+      {{ hostvars[host].oracle_node_vip }}
+    {%- else -%}
+      {{ hostvars[host].ansible_hostname }}{{ oracle_vip }}
+      {%- if hostvars[host].ansible_domain | length > 0 -%}
+        .{{ hostvars[host].ansible_domain }}
+      {%- endif -%}
+    {%- endif -%}
+    {% if oracle_gi_cluster_type | upper == 'FLEX' -%}
+      :HUB
+    {%- endif -%}
+    {%- if not loop.last -%},
+    {%- endif -%} 
+  {%- endfor %}
+{%- endif %}
 
 #-------------------------------------------------------------------------------
 # The value should be a comma separated strings where each string is as shown below
@@ -311,7 +310,7 @@ oracle.install.crs.config.networkInterfaceList=
 # This option is only applicable when CRS_CONFIG is chosen as install option,
 # and STANDALONE is chosen as cluster configuration.
 #------------------------------------------------------------------------------
-oracle.install.crs.configureGIMR=true
+oracle.install.crs.configureGIMR={{ oracle_gi_mgmt_repo | default('false') }}
 
 #------------------------------------------------------------------------------
 # Create a separate ASM DiskGroup to store GIMR data.

--- a/roles/oraswgi-install/templates/grid-install.rsp.21.3.0.0.j2
+++ b/roles/oraswgi-install/templates/grid-install.rsp.21.3.0.0.j2
@@ -247,24 +247,24 @@ oracle.install.crs.config.sites=
 # hostnameprefix:lowerbound-upperbound:hostnamesuffix:vipsuffix
 #
 #-------------------------------------------------------------------------------
-{%  if oracle_gi_cluster_type|upper  == "STANDARD"  or oracle_gi_cluster_type|upper == 'STANDALONE' %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-  {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%} {%- endfor %}{% else %}{% endif %}
-{% endif %}
-
-{% elif oracle_gi_cluster_type|upper == 'FLEX'  %}
-
-{%  if ansible_domain  == ""  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
- {% else  %}
-oracle.install.crs.config.clusterNodes={% if configure_cluster %}{% for host in groups[hostgroup_hub] -%} {{host |regex_replace("^([^.]+)\..*", "\\1")}}.{{ ansible_domain }}:{{ host |regex_replace("^([^.]+)\..*", "\\1")}}{{ oracle_vip }}.{{ ansible_domain }}:HUB{%- if not loop.last -%} , {%- endif -%}{%- endfor %}{% for host in groups[hostgroup_leaf] -%},{{host}}.{{ ansible_domain }}::LEAF {%- if not loop.last -%}  {%- endif -%} {%- endfor %}{% else %}{% endif %}
-
- {% endif %}
-
-{% endif %}
+oracle.install.crs.config.clusterNodes=
+{%- if configure_cluster -%}
+  {%- for host in groups[hostgroup] -%} {{ hostvars[host].ansible_fqdn }}:
+    {%- if hostvars[host].oracle_node_vip is defined -%}
+      {{ hostvars[host].oracle_node_vip }}
+    {%- else -%}
+      {{ hostvars[host].ansible_hostname }}{{ oracle_vip }}
+      {%- if hostvars[host].ansible_domain | length > 0 -%}
+        .{{ hostvars[host].ansible_domain }}
+      {%- endif -%}
+    {%- endif -%}
+    {% if oracle_gi_cluster_type | upper == 'FLEX' -%}
+      :HUB
+    {%- endif -%}
+    {%- if not loop.last -%},
+    {%- endif -%} 
+  {%- endfor %}
+{%- endif %}
 
 #-------------------------------------------------------------------------------
 # The value should be a comma separated strings where each string is as shown below
@@ -503,7 +503,7 @@ oracle.install.crs.config.ignoreDownNodes=
 # and oracle.install.crs.RemoteGIMRCredFile= path of the GIMR cred file
 # No GIMR : oracle.install.crs.configureGIMR=false
 #------------------------------------------------------------------------------
-oracle.install.crs.configureGIMR=
+oracle.install.crs.configureGIMR={{ oracle_gi_mgmt_repo | default('false') }}
 oracle.install.crs.configureRemoteGIMR=
 oracle.install.crs.RemoteGIMRCredFile=
 


### PR DESCRIPTION
Disable configuriation of GI Management Repository
in 19c and 21c.
This could be reenabled with follwoing variable:

oracle_gi_mgmt_repo: true

Refactoring for oracle.install.crs.config.clusterNodes.