### PR TITLE
ansible-lint: more ansible-lint and remove options from skip_list

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,5 +22,4 @@ exclude_paths:
   # old roles without usable playbooks at the moment
   # we cannot change the code without a usable playbook...
   - roles/oraemagent-install
-  - roles/oraswgi-clone
   - roles/oraswracdb-clone

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,4 +22,3 @@ exclude_paths:
   # old roles without usable playbooks at the moment
   # we cannot change the code without a usable playbook...
   - roles/oraemagent-install
-  - roles/oraswracdb-clone

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,7 +21,6 @@ exclude_paths:
 
   # old roles without usable playbooks at the moment
   # we cannot change the code without a usable playbook...
-  - roles/oradb-failover
   - roles/oraemagent-install
   - roles/oraswgi-clone
   - roles/oraswracdb-clone

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -18,7 +18,3 @@ exclude_paths:
   - host_vars
   - inventory
   - library
-
-  # old roles without usable playbooks at the moment
-  # we cannot change the code without a usable playbook...
-  - roles/oraemagent-install

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,9 +4,6 @@ use_default_rules: true
 skip_list:
   - role-name
   # must be fixed at later time
-  - deprecated-local-action
-  - deprecated-command-syntax
-  - ignore-errors
   - var-naming
 
 exclude_paths:

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -24,38 +24,6 @@ jobs:
         uses: Rendanic/ansible-lint-action@tbr
         with:
           targets: |
-            roles/common
-            roles/cxoracle
-            roles/oraasm-createdg
-            roles/oraasm-manage-diskgroups
-            roles/oradb-datapatch
-            roles/oradb-manage-db
-            roles/oradb-manage-grants
-            roles/oradb-manage-parameters
-            roles/oradb-manage-pdb
-            roles/oradb-manage-profiles
-            roles/oradb-manage-redo
-            roles/oradb-manage-roles
-            roles/oradb-manage-services
-            roles/oradb-manage-statspack
-            roles/oradb-manage-tablespace
-            roles/oradb-manage-users
-            roles/oradb-rman
-            roles/orahost
-            roles/orahost-cron
-            roles/orahost-logrotate
-            roles/orahost-ssh
-            roles/orahost-storage
-            roles/orasw-meta
-            roles/oraswdb-golden-image
-            roles/oraswgi-golden-image
-            roles/oraswdb-install
-            roles/oraswdb-manage-patches
-            roles/oraswgi-install
-            roles/oraswgi-manage-patches
-            roles/oraswgi-opatch
-            # deprecated roles
-            roles/oradb-create
-            roles/oradb-delete
+            roles/*
             
           args: ""

--- a/roles/oradb-failover/defaults/main.yml
+++ b/roles/oradb-failover/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
-  oracle_user: oracle                        # THe user that will own the installation
-  oracle_group: oinstall                          # Primary group for oracle_user.
-  oracle_home_gi_cl: "/u01/app/{{ oracle_install_version_gi }}/grid"
-  oracle_db_resource_name: "{{ item.oracle_db_name }}.db"
-  oracle_stage: /u01/stage
+
+oracle_user: oracle                        # THe user that will own the installation
+oracle_group: oinstall                          # Primary group for oracle_user.
+oracle_home_gi_cl: "/u01/app/{{ oracle_install_version_gi }}/grid"
+oracle_db_resource_name: "{{ item.oracle_db_name }}.db"
+oracle_stage: /u01/stage

--- a/roles/oradb-failover/tasks/main.yml
+++ b/roles/oradb-failover/tasks/main.yml
@@ -1,78 +1,82 @@
 ---
 
-  - name: Check if database is added to GI
-    shell: "{{ oracle_home_gi_cl }}/bin/srvctl config database"
-    with_items: oracle_databases
-    when:  item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
-    register: dbcheck
 
-  - name: Remove database from Oracle Restart configuration (if needed)
-    shell: "{{ oracle_home_gi_cl }}/bin/srvctl remove database -d {{ item.oracle_db_name }} -f"
-    with_items: oracle_databases
-    when:  item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node and item.oracle_db_name in dbcheck.results
+- name: Check if database is added to GI
+  shell: "{{ oracle_home_gi_cl }}/bin/srvctl config database"
+  # noqa command-instead-of-shell
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
+  register: dbcheck
 
+- name: Remove database from Oracle Restart configuration (if needed)
+  shell: "{{ oracle_home_gi_cl }}/bin/srvctl remove database -d {{ item.oracle_db_name }} -f"
+  # noqa command-instead-of-shell
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node and item.oracle_db_name in dbcheck.results
 
-  - name: Create adump directory on other servers
-    file: path={{ oracle_base }}/admin/{{ item.oracle_db_name }}/adump state=directory owner={{ oracle_user }} group={{ oracle_group }}
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and not master_node
-
-
-  - name: Setup check script for DB Failover
-    template: src=act_db.pl.j2 dest="{{ oracle_home_gi_cl }}/crs/public/act_db_{{ item.oracle_db_name }}.pl" backup=yes mode=755
-    become_user: "{{ oracle_user }}"
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG'
-    tags:
-      - checkscript
-
-  - name: Setup CRS attribute scripts for DB Failover
-    template: src=attributes.txt.j2 dest="{{ oracle_stage }}/rsp/attributes_{{ item.oracle_db_name }}_crs.rsp" backup=yes
-    become_user: "{{ oracle_user }}"
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG'
-    tags:
-      - checkscript
-  
-  - name: Check if resource is already present
-    shell: "{{ oracle_home_gi_cl }}/bin/crsctl stat res {{ oracle_db_resource_name }} -t"
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
-    register: crsctlcheck
-
-  - name: Add database resource to cluster (if needed)
-    shell: "{{ oracle_home_gi_cl }}/bin/crsctl add resource {{ item.0.oracle_db_name }}.db -type cluster_resource -file {{ oracle_stage }}/rsp/attributes_{{ item.0.oracle_db_name }}_crs.rsp"
-    with_together: 
-        - oracle_databases
-        - crsctlcheck.results
-    when: item.0.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node and 'CRS-2613' in item.1.stdout
-
-  - name: Copy stopscript
-    template: src=shutdown-db.sh.j2 dest={{ oracle_stage }}/rsp/shutdown-db-{{ item.oracle_db_name }}.sh mode=0755 owner={{ oracle_user }} group={{ oracle_group }}
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
-
-  - name: Stop database
-    shell: "{{ oracle_stage }}/rsp/shutdown-db-{{ item.oracle_db_name}}.sh"
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
-    ignore_errors: true
-
-  - name: Start database as a cluster resource
-    shell: "{{ oracle_home_gi_cl}}/bin/crsctl start res {{ oracle_db_resource_name }} "
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
-
-  - name: Check if resource is started
-    shell: "{{ oracle_home_gi_cl}}/bin/crsctl stat res {{ oracle_db_resource_name }} -t"
-    with_items: oracle_databases
-    when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
-    register: statuscheck
-
-  - name: Print status
-    debug: var=item.stdout_lines
-    with_items: statuscheck.results
+- name: Create adump directory on other servers
+  file: path={{ oracle_base }}/admin/{{ item.oracle_db_name }}/adump state=directory owner={{ oracle_user }} group={{ oracle_group }} mode=0750
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and not master_node
 
 
+- name: Setup check script for DB Failover
+  template: src=act_db.pl.j2 dest="{{ oracle_home_gi_cl }}/crs/public/act_db_{{ item.oracle_db_name }}.pl" backup=yes mode=755
+  become_user: "{{ oracle_user }}"
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG'
+  tags:
+    - checkscript
 
+- name: Setup CRS attribute scripts for DB Failover
+  template: src=attributes.txt.j2 dest="{{ oracle_stage }}/rsp/attributes_{{ item.oracle_db_name }}_crs.rsp" backup=yes mode=0644
+  become_user: "{{ oracle_user }}"
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG'
+  tags:
+    - checkscript
 
+- name: Check if resource is already present
+  shell: "{{ oracle_home_gi_cl }}/bin/crsctl stat res {{ oracle_db_resource_name }} -t"
+  # noqa command-instead-of-shell
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
+  register: crsctlcheck
+
+- name: Add database resource to cluster (if needed)
+  shell: "{{ oracle_home_gi_cl }}/bin/crsctl add resource {{ item.0.oracle_db_name }}.db -type cluster_resource -file {{ oracle_stage }}/rsp/attributes_{{ item.0.oracle_db_name }}_crs.rsp"
+  # noqa command-instead-of-shell yaml
+  with_together:
+    - "{{  oracle_databases  }}"
+    - "{{ crsctlcheck.results }}"
+  when: item.0.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node and 'CRS-2613' in item.1.stdout
+
+- name: Copy stopscript
+  template: src=shutdown-db.sh.j2 dest={{ oracle_stage }}/rsp/shutdown-db-{{ item.oracle_db_name }}.sh mode=0755 owner={{ oracle_user }} group={{ oracle_group }} mode=0755
+  # noqa yaml
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
+
+- name: Stop database
+  shell: "{{ oracle_stage }}/rsp/shutdown-db-{{ item.oracle_db_name }}.sh"
+  # noqa command-instead-of-shell yaml ignore-errors
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
+  ignore_errors: true
+
+- name: Start database as a cluster resource
+  shell: "{{ oracle_home_gi_cl }}/bin/crsctl start res {{ oracle_db_resource_name }} "
+  # noqa command-instead-of-shell yaml
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
+
+- name: Check if resource is started
+  shell: "{{ oracle_home_gi_cl }}/bin/crsctl stat res {{ oracle_db_resource_name }} -t"
+  # noqa command-instead-of-shell
+  with_items: "{{ oracle_databases }}"
+  when: item.oracle_db_type|upper  == 'SIFO' and oracle_install_option_gi == 'CRS_CONFIG' and master_node
+  register: statuscheck
+
+- name: Print status
+  debug: var=item.stdout_lines
+  with_items: "{{ statuscheck.results }}"

--- a/roles/oraemagent-install/defaults/main.yml
+++ b/roles/oraemagent-install/defaults/main.yml
@@ -1,24 +1,24 @@
 ---
-  oracle_user: oracle                        # THe user that will own the installation
-  oracle_group: oinstall                          # Primary group for oracle_user.
-  oracle_user_home: "/home/{{ oracle_user }}" # Home directory for oracle_user
-  oracle_em_responsefile: "emagent-{{ em_agent_version }}-{{ ansible_hostname }}.rsp"
-  oracle_stage: /u01/stage
-  oracle_rsp_stage: "{{ oracle_stage }}/rsp"
-  oracle_inventory_loc: /u01/app/oraInventory
-  oracle_base: /u01/app/oracle
-  oracle_home_emag: "{{ em_agent_base_dir }}/core/{{ em_agent_version }}"
-  oracle_profile_name: ".profile_agent"
 
-  em_agent_version: 12.1.0.4.0                          # Version of agent to install
-  em_oms_host: omshost.example.com                      # OMS host fqdn
-  em_em_upload_port: 4903                               # Upload port on the OMS
-  em_agent_registration_password: supersecretpassword   # Registration password on the OMS
-  em_agent_base_dir: /u01/app/oracle/agent
-  em_agent_instance_home: "{{ em_agent_base_dir }}/agent_inst"
-  em_agent_port: 3872                                   # Port on the agent
-  em_agent_home_name: agent12c1                         # Name on the Agent ORACLE_HOME ()
+oracle_user: oracle                        # THe user that will own the installation
+oracle_group: oinstall                          # Primary group for oracle_user.
+oracle_user_home: "/home/{{ oracle_user }}"  # Home directory for oracle_user
+oracle_em_responsefile: "emagent-{{ em_agent_version }}-{{ ansible_hostname }}.rsp"
+oracle_stage: /u01/stage
+oracle_rsp_stage: "{{ oracle_stage }}/rsp"
+oracle_inventory_loc: /u01/app/oraInventory
+oracle_base: /u01/app/oracle
+oracle_home_emag: "{{ em_agent_base_dir }}/core/{{ em_agent_version }}"
+oracle_profile_name: ".profile_agent"
 
-  oracle_sw_image_em_agent:
-         - { filename: 12.1.0.4.0_AgentCore_226.zip, version: 12.1.0.4.0 }
+em_agent_version: 12.1.0.4.0                          # Version of agent to install
+em_oms_host: omshost.example.com                      # OMS host fqdn
+em_em_upload_port: 4903                               # Upload port on the OMS
+em_agent_registration_password: supersecretpassword   # Registration password on the OMS
+em_agent_base_dir: /u01/app/oracle/agent
+em_agent_instance_home: "{{ em_agent_base_dir }}/agent_inst"
+em_agent_port: 3872                                   # Port on the agent
+em_agent_home_name: agent12c1                         # Name on the Agent ORACLE_HOME ()
 
+oracle_sw_image_em_agent:
+        - {filename: 12.1.0.4.0_AgentCore_226.zip, version: 12.1.0.4.0}

--- a/roles/oraemagent-install/tasks/main.yml
+++ b/roles/oraemagent-install/tasks/main.yml
@@ -2,8 +2,8 @@
 
 #  - name: Check if EM is already installed
 #    shell: grep "{{ oracle_home_db  }}" "{{ oracle_inventory_loc }}/ContentsXML/inventory.xml" |wc -l
-#    with_dict: oracle_databases 
-#    tags: 
+#    with_dict: "{{ oracle_databases }}"
+#    tags:
 #    - checkifdbinstall
 #    register: checkdbswinstall
 
@@ -13,93 +13,96 @@
 #    tags:
 #     - checkifdbinstall
 
-  - name: Add new dotprofile (EM Agent)
-    template: src=dotprofile-agent.j2 dest={{ oracle_user_home }}/{{ oracle_profile_name }} owner={{ oracle_user }} group={{ oracle_group }} mode=775 backup=yes
-    tags: 
+- name: Add new dotprofile (EM Agent)
+  template: src=dotprofile-agent.j2 dest={{ oracle_user_home }}/{{ oracle_profile_name }} owner={{ oracle_user }} group={{ oracle_group }} mode=775 backup=yes
+  tags:
     - dotprofileem
 
-  - name: Create EM stage directory (base)
-    file: dest={{ oracle_stage }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directoriesdb
-  
-  - name: Create stage directory (version specific)
-    file: dest={{ oracle_stage }}/{{ item.version }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    with_items: oracle_sw_image_em_agent
-    when: em_agent_version == item.version
-    tags:
-      - directoriesem
+- name: Create EM stage directory (base)
+  file: dest={{ oracle_stage }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directoriesdb
 
-  - name: Create rsp stage directory
-    file: dest={{ oracle_rsp_stage }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directoriesem
+- name: Create stage directory (version specific)
+  file: dest={{ oracle_stage }}/{{ item.version }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  with_items: "{{ oracle_sw_image_em_agent }}"
+  when: em_agent_version == item.version
+  tags:
+    - directoriesem
 
-  - name: Create ORACLE_INVENTORY directory
-    file: dest={{ oracle_inventory_loc }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directoriesem
-  
-  - name: Create ORACLE_BASE directory
-    file: dest={{ oracle_base }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directoriesem
-  
+- name: Create rsp stage directory
+  file: dest={{ oracle_rsp_stage }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directoriesem
 
-  - name: Transfer oracle EM Agent installfiles to server (www)
-    get_url: url={{ oracle_sw_source_www }}/{{ item.filename }} dest={{ oracle_stage }} mode=775
-    with_items: oracle_sw_image_em_agent
-    when: not is_sw_source_local and em_agent_version == item.version
-    become_user: "{{ oracle_user }}"
-    tags:
-      - oraemsw
+- name: Create ORACLE_INVENTORY directory
+  file: dest={{ oracle_inventory_loc }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directoriesem
 
-  - name: Transfer oracle EM Agent installfiles to server (local)
-    copy: src={{ oracle_sw_source_local }}/{{ item.filename }} dest={{ oracle_stage }} mode=775
-    with_items: oracle_sw_image_em_agent
-    when: is_sw_source_local and em_agent_version == item.version
-    become_user: "{{ oracle_user }}"
-    tags:
-      - oraemsw
+- name: Create ORACLE_BASE directory
+  file: dest={{ oracle_base }} mode=775 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directoriesem
 
-  - name: Extract files to stage-area
-    unarchive: src={{ oracle_stage }}/{{ item.filename }}  dest={{ oracle_stage }}/{{ item.version }} copy=no 
-    with_items: oracle_sw_image_em_agent
-    when: em_agent_version == item.version
-    become_user: "{{ oracle_user }}"
-    tags:
-      - oradbswunpack
 
-  - name: Setup response file for install (EM Agent)
-    template: src=agent.rsp.{{ em_agent_version }}.j2 dest={{ oracle_rsp_stage }}/{{ oracle_em_responsefile }}
-    become_user: "{{ oracle_user }}"
-    tags:
-      - responsefileswem
+- name: Transfer oracle EM Agent installfiles to server (www)
+  get_url: url={{ oracle_sw_source_www }}/{{ item.filename }} dest={{ oracle_stage }} mode=775
+  with_items: "{{ oracle_sw_image_em_agent }}"
+  when: not is_sw_source_local and em_agent_version == item.version
+  become_user: "{{ oracle_user }}"
+  tags:
+    - oraemsw
 
-  - name: Install EM Agent (1)
-    shell: "{{ oracle_stage }}/{{ item.version }}/agentDeploy.sh AGENT_BASE_DIR={{ em_agent_base_dir }} RESPONSE_FILE={{ oracle_rsp_stage }}/{{ oracle_em_responsefile }}"
-    with_items: oracle_sw_image_em_agent
-    become_user: "{{ oracle_user }}"
-    when: em_agent_version == item.version
-    register: emagent_install
+- name: Transfer oracle EM Agent installfiles to server (local)
+  copy: src={{ oracle_sw_source_local }}/{{ item.filename }} dest={{ oracle_stage }} mode=775
+  with_items: "{{ oracle_sw_image_em_agent }}"
+  when: is_sw_source_local and em_agent_version == item.version
+  become_user: "{{ oracle_user }}"
+  tags:
+    - oraemsw
 
-  - name: Install EM Agent (2)
-    debug: var=emagent_install.stdout_lines
-    with_items: emagent_install.results
-    
-  - name: Run root.sh
-    shell: "{{ oracle_home_emag }}/root.sh"
+- name: Extract files to stage-area
+  unarchive: src={{ oracle_stage }}/{{ item.filename }}  dest={{ oracle_stage }}/{{ item.version }} copy=no
+  with_items: "{{ oracle_sw_image_em_agent }}"
+  when: em_agent_version == item.version
+  become_user: "{{ oracle_user }}"
+  tags:
+    - oradbswunpack
 
-  - name: Wait for the agent to start
-    wait_for: host={{ ansible_fqdn }} port={{ em_agent_port }} timeout=120
+- name: Setup response file for install (EM Agent)
+  template: src=agent.rsp.{{ em_agent_version }}.j2 dest={{ oracle_rsp_stage }}/{{ oracle_em_responsefile }}
+  # noqa risky-file-permissions
+  become_user: "{{ oracle_user }}"
+  tags:
+    - responsefileswem
 
-  - name: Check status for EM Agent
-    shell: "{{ oracle_home_emag }}/bin/emctl status agent"
-    become_user: "{{ oracle_user }}"
-    register: emctl_out
-    tags: emagent-status
+- name: Install EM Agent (1)
+  shell: "{{ oracle_stage }}/{{ item.version }}/agentDeploy.sh AGENT_BASE_DIR={{ em_agent_base_dir }} RESPONSE_FILE={{ oracle_rsp_stage }}/{{ oracle_em_responsefile }}"
+  # noqa command-instead-of-shell no-changed-when yaml
+  with_items: "{{ oracle_sw_image_em_agent }}"
+  become_user: "{{ oracle_user }}"
+  when: em_agent_version == item.version
+  register: emagent_install
 
-  - name: Print status
-    debug: var=emctl_out.stdout_lines
-    tags: emagent-status
-    
+- name: Install EM Agent (2)
+  debug: var=emagent_install.stdout_lines
+  with_items: "{{ emagent_install.results }}"
+
+- name: Run root.sh
+  shell: "{{ oracle_home_emag }}/root.sh"
+  # noqa command-instead-of-shell no-changed-when
+
+- name: Wait for the agent to start
+  wait_for: host={{ ansible_fqdn }} port={{ em_agent_port }} timeout=120
+
+- name: Check status for EM Agent
+  shell: "{{ oracle_home_emag }}/bin/emctl status agent"
+  # noqa command-instead-of-shell no-changed-when
+  become_user: "{{ oracle_user }}"
+  register: emctl_out
+  tags: emagent-status
+
+- name: Print status
+  debug: var=emctl_out.stdout_lines
+  tags: emagent-status

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -156,7 +156,7 @@
     - sudoadd
 
 - name: ssh-keys | Generate SSH keys
-  local_action: shell rm -f /tmp/id_rsa*; ssh-keygen -q -N "" -f /tmp/id_rsa ; chmod +r /tmp/id_rsa; cat /tmp/id_rsa.pub > /tmp/authorized_keys
+  local_action: shell rm -f /tmp/id_rsa*; ssh-keygen -q -N "" -f /tmp/id_rsa ; chmod +r /tmp/id_rsa; cat /tmp/id_rsa.pub > /tmp/authorized_keys  # noqa yaml deprecated-command-syntax deprecated-local-action ignore-errors
   ignore_errors: true
   run_once: "{{ configure_cluster }}"
   when: configure_ssh and configure_cluster and old_ssh_config
@@ -189,7 +189,7 @@
     - sshkeys
 
 - name: ssh-keys | Add short name to known_hosts
-  local_action: shell ssh-keyscan -p {{ ansible_ssh_port|default(22) }} -H {{ ansible_hostname }} 2> /dev/null >> {{ keyfile }}
+  local_action: shell ssh-keyscan -p {{ ansible_ssh_port|default(22) }} -H {{ ansible_hostname }} 2> /dev/null >> {{ keyfile }}  # noqa deprecated-local-action ignore-errors yaml
   ignore_errors: true
   become: false
   when: configure_ssh and configure_cluster and old_ssh_config
@@ -197,7 +197,7 @@
     - sshkeys
 
 - name: ssh-keys | Add FQDN to known_hosts
-  local_action: shell ssh-keyscan -p {{ ansible_ssh_port|default(22) }} -H {{ ansible_fqdn }} 2> /dev/null >> {{ keyfile }}
+  local_action: shell ssh-keyscan -p {{ ansible_ssh_port|default(22) }} -H {{ ansible_fqdn }} 2> /dev/null >> {{ keyfile }}  # noqa yaml ignore-errors deprecated-local-action
   ignore_errors: true
   become: false
   when: configure_ssh and configure_cluster and old_ssh_config
@@ -205,7 +205,7 @@
     - sshkeys
 
 - name: ssh-keys | Add IPv4 to known_hosts
-  local_action: shell ssh-keyscan -p {{ ansible_ssh_port|default(22) }} -H {{ ansible_default_ipv4.address  }} 2> /dev/null >> {{  keyfile }}
+  local_action: shell ssh-keyscan -p {{ ansible_ssh_port|default(22) }} -H {{ ansible_default_ipv4.address  }} 2> /dev/null >> {{  keyfile }}  # noqa yaml ignore-errors deprecated-local-action
   ignore_errors: true
   become: false
   when: configure_ssh and configure_cluster and old_ssh_config
@@ -227,7 +227,7 @@
     - sshkeys
 
 - name: ssh-keys | Remove generated keys from control machine
-  local_action: file  path="{{ item }}" state=absent
+  local_action: file  path="{{ item }}" state=absent  # noqa deprecated-local-action ignore-errors
   with_items:
     - "{{ ssh_keys }}"
     - "{{ keyfile }}"

--- a/roles/oraswgi-clone/tasks/main.yml
+++ b/roles/oraswgi-clone/tasks/main.yml
@@ -1,84 +1,90 @@
 ---
 
-  - name: Add new dotprofile
-    template: src=dotprofile-gi.j2 dest={{ oracle_user_home }}/{{ oracle_profile_name }} owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
-    tags: 
-    - dotprofile
+- name: Add new dotprofile
+  template: src=dotprofile-gi.j2 dest={{ oracle_user_home }}/{{ oracle_profile_name }} owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
+  tags:
+  - dotprofile
 
-  - name: Create stage directory
-    file: dest={{ oracle_stage }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
-  
-  - name: Create ORACLE_INVENTORY directory
-    file: dest={{ oracle_inventory_loc }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
-  
-  - name: Create ORACLE_BASE directory
-    file: dest={{ oracle_base }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
-  
-  - name: Create ORACLE_HOME directory
-    file: dest={{ oracle_home }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
+- name: Create stage directory
+  file: dest={{ oracle_stage }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - name: Copy oracle image to server
-    get_url: url={{ oracle_sw_source }}/{{ oracle_sw_image_gi }} dest={{ oracle_stage }} mode=755
-    tags:
-      - oragridimageget
+- name: Create ORACLE_INVENTORY directory
+  file: dest={{ oracle_inventory_loc }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - name: Are files already unpacked?
-    shell: du -ks {{ oracle_home }} |awk '{print  $1 }'
-    register: size
-    tags:
-      - oragridimageunpack
+- name: Create ORACLE_BASE directory
+  file: dest={{ oracle_base }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - debug: var=size.stdout
-    tags:
-      - oragridimageunpack
-  
-  - name: Extract files to ORACLE_HOME
-    shell: tar -xf {{ oracle_stage }}/{{ oracle_sw_image_gi }} -C {{ oracle_home }}
-    when:  size.stdout < "8902016"
-    tags:
-      - oragridimageunpack
+- name: Create ORACLE_HOME directory
+  file: dest={{ oracle_home }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - name: Setup clone script
-    template: src=clone.sh.j2 dest={{ oracle_stage }}/clone-{{ oracle_home_name }}.sh owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
-    tags:
-      - clonescript
+- name: Copy oracle image to server
+  get_url: url={{ oracle_sw_source }}/{{ oracle_sw_image_gi }} dest={{ oracle_stage }} mode=755
+  tags:
+    - oragridimageget
 
-  - name: Clone new ORACLE_HOME and add to inventory
-    shell: perl {{ oracle_home }}/clone/bin/clone.pl -silent ORACLE_BASE={{ oracle_base }} ORACLE_HOME={{ oracle_home }} ORACLE_HOME_NAME={{ oracle_home_name }} INVENTORY_LOCATION={{ oracle_inventory_loc }} -O'"CLUSTER_NODES={"{{ oracle_cluster_nodes }}"}"' -O'"LOCAL_NODE={{ oracle_local_node }}"' CRS=TRUE 
-  #- debug: msg="CLUSTER_NODES={"{{ oracle_cluster_nodes }}"} -O LOCAL_NODE={{ oracle_local_node }}"
-    register: cloneout
-    tags:
-      - oragridclone
+- name: Are files already unpacked?
+  shell: du -ks {{ oracle_home }} |awk '{print  $1 }'
+  # noqa no-changed-when risky-shell-pipe
+  register: size
+  tags:
+    - oragridimageunpack
 
-  - debug: var=cloneout.stdout_lines
-    tags:
-     - opatchls
+- debug: var=size.stdout
+  # noqa unnamed-task
+  tags:
+    - oragridimageunpack
 
-  - name: Run oraInstroot script after clone of ORACLE_HOME
-    shell: sudo su - -c {{ oracle_inventory_loc }}/orainstRoot.sh
-    tags:
-      - runrootclone
+- name: Extract files to ORACLE_HOME
+  shell: tar -xf {{ oracle_stage }}/{{ oracle_sw_image_gi }} -C {{ oracle_home }}
+  # noqa command-instead-of-shell command-instead-of-module
+  when: size.stdout < "8902016"
+  tags:
+    - oragridimageunpack
+
+- name: Setup clone script
+  template: src=clone.sh.j2 dest={{ oracle_stage }}/clone-{{ oracle_home_name }}.sh owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
+  tags:
+    - clonescript
+
+- name: Clone new ORACLE_HOME and add to inventory
+  shell: perl {{ oracle_home }}/clone/bin/clone.pl -silent ORACLE_BASE={{ oracle_base }} ORACLE_HOME={{ oracle_home }} ORACLE_HOME_NAME={{ oracle_home_name }} INVENTORY_LOCATION={{ oracle_inventory_loc }} -O'"CLUSTER_NODES={"{{ oracle_cluster_nodes }}"}"' -O'"LOCAL_NODE={{ oracle_local_node }}"' CRS=TRUE
+  # noqa no-changed-when risky-shell-pipe yaml
+  register: cloneout
+  tags:
+    - oragridclone
+
+- debug: var=cloneout.stdout_lines
+  # noqa unnamed-task
+  tags:
+    - opatchls
+
+- name: Run oraInstroot script after clone of ORACLE_HOME
+  shell: sudo su - -c {{ oracle_inventory_loc }}/orainstRoot.sh
+  # noqa no-changed-when command-instead-of-shell
+  tags:
+    - runrootclone
 
 #  - name: Run root script after clone of ORACLE_HOME
 #    shell: sudo su - -c {{ oracle_home }}/root.sh
 #    tags:
 #      - runrootclone
 
-  - name: Check opatch lsinventory
-    shell: "{{ oracle_home }}/OPatch/opatch lsinventory"
-    register: opatchls
-    tags:
-     - opatchls
-    
-  - debug: var=opatchls.stdout_lines
-    tags:
-     - opatchls
+- name: Check opatch lsinventory
+  shell: "{{ oracle_home }}/OPatch/opatch lsinventory"
+  # noqa no-changed-when command-instead-of-shell
+  register: opatchls
+  tags:
+    - opatchls
 
+- debug: var=opatchls.stdout_lines
+  # noqa unnamed-task
+  tags:
+    - opatchls

--- a/roles/oraswgi-clone/vars/main.yml
+++ b/roles/oraswgi-clone/vars/main.yml
@@ -1,4 +1,4 @@
 ---
-  oracle_home_name_gi: "grid_{{ oracle_install_version_gi }}"         # This parameter is used when cloning Grid Infrastructure
-  oracle_hostname: "{{ ansible_fqdn }}"                            # Full (FQDN) name of the host
 
+oracle_home_name_gi: "grid_{{ oracle_install_version_gi }}"         # This parameter is used when cloning Grid Infrastructure
+oracle_hostname: "{{ ansible_fqdn }}"                            # Full (FQDN) name of the host

--- a/roles/oraswgi-install/tasks/12.1.0.2.yml
+++ b/roles/oraswgi-install/tasks/12.1.0.2.yml
@@ -28,6 +28,7 @@
 
 - name: install-home-gi | Install cvuqdisk rpm
   yum: name="{{ oracle_stage_install }}/{{ oracle_install_version_gi }}/grid/rpm/{{ cvuqdisk_rpm }}" state=present
+  # noqa ignore-errors
   when: configure_cluster
   tags: cvuqdisk
   ignore_errors: true

--- a/roles/oraswgi-install/tasks/12.2.0.1.yml
+++ b/roles/oraswgi-install/tasks/12.2.0.1.yml
@@ -49,6 +49,7 @@
 
 - name: install-home-gi | Install cvuqdisk rpm
   yum: name="{{ oracle_home_gi }}/cv/rpm/{{ cvuqdisk_rpm }}" state=present
+  # noqa ignore-errors
   when: configure_cluster
   tags: cvuqdisk
   ignore_errors: true

--- a/roles/oraswgi-install/tasks/18.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/18.3.0.0.yml
@@ -47,6 +47,7 @@
 
 - name: install-home-gi | Install cvuqdisk rpm
   yum: name="{{ oracle_home_gi }}/cv/rpm/{{ cvuqdisk_rpm }}" state=present
+  # noqa ignore-errors
   when: configure_cluster
   tags: cvuqdisk
   ignore_errors: true

--- a/roles/oraswgi-install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/19.3.0.0.yml
@@ -39,6 +39,7 @@
 
 - name: install-home-gi | Install cvuqdisk rpm
   yum: name="{{ oracle_home_gi }}/cv/rpm/{{ cvuqdisk_rpm }}" state=present
+  # noqa ignore-errors
   when: configure_cluster
   tags: cvuqdisk
   ignore_errors: true

--- a/roles/oraswracdb-clone/tasks/main.yml
+++ b/roles/oraswracdb-clone/tasks/main.yml
@@ -1,55 +1,58 @@
 ---
 
-  - name: Add new dotprofile
-    template: src=dotprofile-gi.j2 dest={{ oracle_user_home }}/{{ oracle_profile_name }} owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
-    tags: 
+- name: Add new dotprofile
+  template: src=dotprofile-gi.j2 dest={{ oracle_user_home }}/{{ oracle_profile_name }} owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
+  tags:
     - dotprofile
 
-  - name: Create stage directory
-    file: dest={{ oracle_stage }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
-  
-  - name: Create ORACLE_INVENTORY directory
-    file: dest={{ oracle_inventory_loc }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
-  
-  - name: Create ORACLE_BASE directory
-    file: dest={{ oracle_base }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
-  
-  - name: Create ORACLE_HOME directory
-    file: dest={{ oracle_home }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
-    tags:
-      - directories
+- name: Create stage directory
+  file: dest={{ oracle_stage }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - name: Copy oracle image to server
-    get_url: url={{ oracle_image_source }}/{{ oracle_sw_image_db }} dest={{ oracle_stage }} mode=755
-    tags:
-      - oradbimageget
+- name: Create ORACLE_INVENTORY directory
+  file: dest={{ oracle_inventory_loc }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - name: Are files already unpacked?
-    shell: du -ks {{ oracle_home }} |awk '{print  $1 }'
-    register: size
-    tags:
-      - oradbimageunpack
+- name: Create ORACLE_BASE directory
+  file: dest={{ oracle_base }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - debug: var=size.stdout
-    tags:
-      - oradbimageunpack
-  
-  - name: Extract files to ORACLE_HOME
-    shell: tar -xf {{ oracle_stage }}/{{ oracle_sw_image_db }} -C {{ oracle_home }}
-    when:  size.stdout < "8902016"
-    tags:
-      - oradbimageunpack
+- name: Create ORACLE_HOME directory
+  file: dest={{ oracle_home }} mode=755 owner={{ oracle_user }} group={{ oracle_group }} state=directory
+  tags:
+    - directories
 
-  - name: Setup clone script
-    template: src=clone.sh.j2 dest={{ oracle_stage }}/clone-{{ oracle_home_name }}.sh owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
-    tags:
-      - clonescript
+- name: Copy oracle image to server
+  get_url: url={{ oracle_image_source }}/{{ oracle_sw_image_db }} dest={{ oracle_stage }} mode=755
+  tags:
+    - oradbimageget
+
+- name: Are files already unpacked?
+  shell: du -ks {{ oracle_home }} |awk '{print  $1 }'
+  # noqa no-changed-when risky-shell-pipe
+  register: size
+  tags:
+    - oradbimageunpack
+
+- debug: var=size.stdout
+  # noqa unnamed-task
+  tags:
+    - oradbimageunpack
+
+- name: Extract files to ORACLE_HOME
+  shell: tar -xf {{ oracle_stage }}/{{ oracle_sw_image_db }} -C {{ oracle_home }}
+  # noqa command-instead-of-module command-instead-of-shell
+  when: size.stdout < "8902016"
+  tags:
+    - oradbimageunpack
+
+- name: Setup clone script
+  template: src=clone.sh.j2 dest={{ oracle_stage }}/clone-{{ oracle_home_name }}.sh owner={{ oracle_user }} group={{ oracle_group }} mode=755 backup=yes
+  tags:
+    - clonescript
 
 #  - name: Clone new ORACLE_HOME and add to inventory
 #    shell: perl {{ oracle_home }}/clone/bin/clone.pl -silent ORACLE_BASE={{ oracle_base }} ORACLE_HOME={{ oracle_home }} ORACLE_HOME_NAME={{ oracle_home_name }} -O'"CLUSTER_NODES={"{{ oracle_cluster_nodes }}"}"' -O'"LOCAL_NODE={{ oracle_local_node }}"'
@@ -65,4 +68,3 @@
 #    shell: sudo su - -c {{ oracle_home }}/root.sh
 #    tags:
 #      - runrootclone
-


### PR DESCRIPTION
The following options have been removed from skip_list

- deprecated-local-action
- deprecated-command-syntax
- ignore-errors

Fixed following roles:

- roles/oradb-failover
- roles/oraemagent-install
- roles/oraswgi-clone
- roles/oraswracdb-clone