### PR TITLE
orahost: added support for swap in host_fs_layout, fixed linter in ha…

### DIFF
--- a/roles/orahost/handlers/main.yml
+++ b/roles/orahost/handlers/main.yml
@@ -3,5 +3,7 @@
   service: name=network state=restarted
 
 - name: restart server
-  shell: reboot
-  # noqa command-instead-of-shell
+  command: reboot
+
+- name: swapon
+  command: swapon -a

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -291,7 +291,26 @@
   with_subelements:
     - "{{ host_fs_layout }}"
     - filesystem
-  when: configure_host_disks
+  when:
+    - configure_host_disks
+    - item.1.fstype is defined
+    - item.1.fstype != 'swap'
+  tags: hostfs
+
+- name: filesytem | add swap to fstab
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    regexp: '^/dev/{{ item.0.vgname }}/{{ item.1.lvname }} '
+    line: "/dev/{{ item.0.vgname }}/{{ item.1.lvname }} swap swap defaults 0 0"
+  with_subelements:
+    - "{{ host_fs_layout }}"
+    - filesystem
+  when:
+    - configure_host_disks
+    - item.1.fstype is defined
+    - item.1.fstype == 'swap'
+  notify:
+    - swapon
   tags: hostfs
 
 - name: filesystem | Change permission on directories


### PR DESCRIPTION
…ndler

fstype: swap could be used in host_fs_layout for adding swap on
logical volumes.