### PR TITLE
orahost-storage: added option nolock to dnfsoptions

### DIFF
--- a/roles/orahost-storage/defaults/main.yml
+++ b/roles/orahost-storage/defaults/main.yml
@@ -18,7 +18,7 @@ partition_suffix: "{% if multipath |lower == 'dm-multipath' and ansible_distribu
 asmlib_binary: /usr/sbin/oracleasm
 
 dnfstaboptions: "{%- if item.1.fstaboptions is defined %}{{ item.1.fstaboptions }}
-                  {%- else %}rw,bg,hard,nointr,tcp,vers=3,timeo=600,rsize=32768,wsize=32768{% endif %}"
+                  {%- else %}rw,bg,hard,nointr,tcp,vers=3,timeo=600,rsize=32768,wsize=32768,nolock{% endif %}"
 
 # asm_diskgroups:
 #  - diskgroup: crs


### PR DESCRIPTION
See: ORA-27038,ORA-01580: Error Creating Control Backup File on NFS mount point from SQL or Rman (Doc ID 2710341.1)