### PR TITLE
add support for providing password has instead of cleartext password

### DIFF
--- a/roles/oradb-manage-users/tasks/main.yml
+++ b/roles/oradb-manage-users/tasks/main.yml
@@ -10,8 +10,8 @@
     password={{ db_password_cdb }}
     mode="{{ db_mode }}"
     schema={{ item.1.schema }}
-    schema_password={{ user_cdb_password }}
-    schema_password_hash={{ user_cdb_password_hash | default(omit) }}
+    schema_password={{ item.1.password_is_hash | default(false) | ternary(omit,user_cdb_password) }}
+    schema_password_hash={{ item.1.password_is_hash | default(false) | ternary(user_cdb_password,omit) }}
     profile={{ item.1.profile |default (omit) }}
     state={{ item.1.state }}
     default_tablespace={{ item.1.default_tablespace |default (omit) }}
@@ -42,8 +42,8 @@
     password={{ db_password_pdb }}
     mode="{{ db_mode }}"
     schema={{ item.1.schema }}
-    schema_password={{ user_pdb_password }}
-    schema_password_hash={{ user_pdb_password_hash | default(omit) }}
+    schema_password={{ item.1.password_is_hash | default(false) | ternary(omit,user_pdb_password) }}
+    schema_password_hash={{ item.1.password_is_hash | default(false) | ternary(user_pdb_password,omit) }}
     profile={{ item.1.profile |default (omit) }}
     state={{ item.1.state }}
     default_tablespace={{ item.1.default_tablespace |default (omit) }}


### PR DESCRIPTION
With this PR it is now possible to specify with ```password_is_hash: bool``` in ```oracle_databases.users[*]``` / ```oracle_pdbs.users[*]``` that for given user dbpasswords contains a password hash and not cleartext password.
With this the user will be created with ```IDENTIFIED BY VALUES``` instead of ```IDENTIFIED BY```