### PR TITLE
OL/RHEL8 fixes for Grid-Infrastructure/Restart

### DIFF
--- a/roles/oraswgi-install/tasks/19.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/19.3.0.0.yml
@@ -65,9 +65,10 @@
       tags: cvuqdisk
 
     - name: install-home-gi | Install cvuqdisk rpm
-      package:
+      yum:
         name: "{{ oracle_rsp_stage }}/{{ cvuqdisk_rpm }}"
         state: present
+        disable_gpg_check: true
       tags: cvuqdisk
 
   when:

--- a/roles/oraswgi-install/tasks/21.3.0.0.yml
+++ b/roles/oraswgi-install/tasks/21.3.0.0.yml
@@ -65,9 +65,10 @@
       tags: cvuqdisk
 
     - name: install-home-gi | Install cvuqdisk rpm
-      package:
+      yum:
         name: "{{ oracle_rsp_stage }}/{{ cvuqdisk_rpm }}"
         state: present
+        disable_gpg_check: true
       tags: cvuqdisk
 
   when:

--- a/roles/oraswgi-install/tasks/runcluvfy.yml
+++ b/roles/oraswgi-install/tasks/runcluvfy.yml
@@ -6,6 +6,19 @@
       when:
         - configure_cluster
 
+    # GI < 19.11 + OL8 is not supported by Oracle!
+    # ansible-oracle supports no preinstall patching at the moment
+    # runcluvfy.sh is stuck during execution.
+    # => Golden-Image with 19.11+ is mandatory for installation
+    # => We do NOT look into the archive
+    - name: assert that OL8 is using Golden-Image during unzip
+      assert:
+        that: oracle_install_image_gi is defined
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version | int == 8
+        - oracle_install_version_gi == "19.3.0.0"
+
     - name: install-home-gi | Execute runcluvfy.sh for Grid-Infrastructure
       command:
         argv:


### PR DESCRIPTION
- oraswgi: move from package to yum for cvuqdisk.rpm
OL8 requires a signature for all RPMs during installation.
We need to switch from package to yum with disable_gpg_check.
- oraswgi: assert OL8 and GI 19.3 without RU
ansible-oracle has no support for prepatch before execution of GrindSetup.sh.
The runclufy is stuck on OL8 when RU 19.11 is not installed.
The assert stops the execution, when no Golden-Image with RU 19.11 or
newer has been selected.