### PR TITLE
bugfix: gold image copy path

### DIFF
--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -46,7 +46,7 @@
 - block:  # noqa unnamed-task
     - name: install-home-db | Extract files
       unarchive:
-        src={{ oracle_stage }}/{{ oracle_sw_source_local }}/{{ db_homes_config[dbh.home].imagename | default(item[0].filename) }}
+        src={{ oracle_stage }}/{{ db_homes_config[dbh.home].imagename | default(item[0].filename) }}
         dest={{ oracle_home_db }}
         copy=no
         creates="{{ oracle_home_db }}/{{ item[0].creates }}"


### PR DESCRIPTION
This PR fixes problems, when after copying the golden image from ansible controller to the target host, it was looked up under wrong path.