### PR TITLE
bugfix hardcoded /home/oracle - use oracle_user_home

### DIFF
--- a/roles/oradb-create/templates/dotprofile-db.j2
+++ b/roles/oradb-create/templates/dotprofile-db.j2
@@ -21,7 +21,7 @@ get_sid=$(ps -ef | grep "ora_pmon_$ORACLE_DBNAME" |grep -v grep | sed 's/^.*pmon
         export SHLIB_PATH
         LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export LD_LIBRARY_PATH
-        SQLPATH=/home/oracle/.Scripts
+        SQLPATH={{ oracle_user_home }}/.Scripts
         export SQLPATH
         export ORACLE_DBNAME={{ dbh.oracle_db_name }}
         export ORACLE_SID=${get_sid:-$ORACLE_DBNAME}

--- a/roles/oradb-manage-db/defaults/main.yml
+++ b/roles/oradb-manage-db/defaults/main.yml
@@ -3,9 +3,9 @@
 hostgroup: "{{ group_names[0] }}"
 oracle_dbca_rsp: "dbca_{{ dbh.oracle_db_name }}.rsp"        # Name of responsefile used by dbca. One per database
 oracle_netca_rsp: "netca_{{ dbh.home }}_{{ listener_name_template }}.rsp"
-oracle_user: oracle                        # User that will own the Oracle Installations.
-oracle_user_home: "/home/{{ oracle_user }}"  # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
-oracle_group: oinstall                          # Primary group for oracle_user.
+# oracle_user: oracle                        # User that will own the Oracle Installations.
+# oracle_user_home: "/home/{{ oracle_user }}"  # Home directory for oracle_user. Needed for passing in ssh-keys, profiles etc
+# oracle_group: oinstall                          # Primary group for oracle_user.
 oracle_dba_group: dba                          # Primary group for oracle_user.
 grid_dba_group: asmdba                          # Primary group for oracle_user.
 

--- a/roles/oradb-manage-db/tasks/manage-db.yml
+++ b/roles/oradb-manage-db/tasks/manage-db.yml
@@ -53,7 +53,7 @@
 - name: manage-db | add dotprofile
   template:
     src: dotprofile-db.j2
-    dest: "/home/{{ oracle_user }}/.profile_{{ dbh.oracle_db_instance_name | default(dbh.oracle_db_name) }}"
+    dest: "{{ oracle_user_home }}/.profile_{{ dbh.oracle_db_instance_name | default(dbh.oracle_db_name) }}"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"
     mode: 0660
@@ -163,7 +163,7 @@
 
 - name: manage-db | remove dotprofile
   file:
-    path: "/home/{{ oracle_user }}/.profile_{{ dbh.oracle_db_name }}"
+    path: "{{ oracle_user_home }}/.profile_{{ dbh.oracle_db_name }}"
     state: absent
   when: dbh.state|lower == 'absent'
   tags: create_cdb,dotprofile_db

--- a/roles/oradb-manage-db/templates/dotprofile-db.j2
+++ b/roles/oradb-manage-db/templates/dotprofile-db.j2
@@ -21,7 +21,7 @@ get_sid=$(ps -ef | grep "ora_pmon_$ORACLE_DBNAME" |grep -v grep | sed 's/^.*pmon
         export SHLIB_PATH
         LD_LIBRARY_PATH=$ORACLE_HOME/lib
         export LD_LIBRARY_PATH
-        SQLPATH=/home/oracle/.Scripts
+        SQLPATH={{ oracle_user_home }}/.Scripts
         export SQLPATH
         export ORACLE_DBNAME={{ dbh.oracle_db_name }}
         get_sid=$(ps -ef | grep "ora_pmon_$ORACLE_DBNAME" |grep -v grep | sed 's/^.*pmon_//g')

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -118,6 +118,7 @@
     group: "{{ item.primgroup }}"
     groups: "{{ item.othergroups }}"
     uid: "{{ item.uid }}"
+    home: "{{ item.home | default(omit) }}"
     generate_ssh_key: true
     append: true
     state: present
@@ -132,6 +133,7 @@
     group: "{{ item.primgroup }}"
     groups: "{{ item.othergroups }}"
     uid: "{{ item.uid }}"
+    home: "{{ item.home | default(omit) }}"
     generate_ssh_key: true
     append: true
     state: present
@@ -165,7 +167,7 @@
     - sshkeys
 
 - name: ssh-keys | Add ssh-keys & authorized_keys to oracle user
-  copy: src={{ item[1] }} dest=/home/{{ item[0].username }}/.ssh  owner={{ item[0].username }} group={{ item[0].primgroup }} force=yes mode=0600
+  copy: src={{ item[1] }} dest={{ item[0].home | default(oracle_user_home | regex_replace('[^/]+$','') + item[0].username) }}/.ssh  owner={{ item[0].username }} group={{ item[0].primgroup }} force=yes mode=0600
   when: configure_ssh and configure_cluster and old_ssh_config
   with_nested:
     - "{{ oracle_users }}"
@@ -176,7 +178,7 @@
 - name: ssh-keys | Add ssh-keys & authorized_keys to grid user
   copy:
     src: "{{ item[1] }}"
-    dest: "/home/{{ item[0].username }}/.ssh"
+    dest: "{{ item[0].home | default(oracle_user_home | regex_replace('[^/]+$','') + item[0].username) }}/.ssh"
     owner: "{{ item[0].username }}"
     group: "{{ item[0].primgroup }}"
     force: true
@@ -213,14 +215,14 @@
     - sshkeys
 
 - name: ssh-keys | Copy known_hosts to oracle user
-  copy: src={{ keyfile }} dest=/home/{{ item.username }}/.ssh/known_hosts owner={{ item.username }} group={{ item.primgroup }} mode=0644
+  copy: src={{ keyfile }} dest={{ item.home | default(oracle_user_home | regex_replace('[^/]+$','') + item.username) }}/.ssh/known_hosts owner={{ item.username }} group={{ item.primgroup }} mode=0644
   with_items: "{{ oracle_users }}"
   when: configure_ssh and configure_cluster and old_ssh_config
   tags:
     - sshkeys
 
 - name: ssh-keys | Copy known_hosts to grid user
-  copy: src={{ keyfile }} dest=/home/{{ item.username }}/.ssh/known_hosts owner={{ item.username }} group={{ item.primgroup }} mode=0644
+  copy: src={{ keyfile }} dest={{ item.home | default(oracle_user_home | regex_replace('[^/]+$','') + item.username) }}/.ssh/known_hosts owner={{ item.username }} group={{ item.primgroup }} mode=0644
   with_items: "{{ grid_users }}"
   when: configure_ssh and configure_cluster and role_separation and old_ssh_config
   tags:

--- a/roles/oraswdb-install/tasks/install-home-db.yml
+++ b/roles/oraswdb-install/tasks/install-home-db.yml
@@ -23,7 +23,7 @@
 - name: install-home-db | add dotprofile
   template:
     src: dotprofile-home.j2
-    dest: "/home/{{ oracle_user }}/{{ oracle_profile_name }}"
+    dest: "{{ oracle_user_home }}/{{ oracle_profile_name }}"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"
     mode: 0660

--- a/roles/oraswdb-install/templates/dotprofile-home.j2
+++ b/roles/oraswdb-install/templates/dotprofile-home.j2
@@ -19,7 +19,7 @@
         export LD_LIBRARY_PATH
         TNS_ADMIN=$ORACLE_HOME/network/admin
         export TNS_ADMIN
-        SQLPATH=/home/oracle/.Scripts
+        SQLPATH={{ oracle_user_home }}/.Scripts
         export SQLPATH
         ORACLE_SID=
         export ORACLE_SID


### PR DESCRIPTION
This PR fixes a problem where oracle user home directory has been hardcoded to be under /home.
In some installations, this is not the case and now it is possible to use oracle_user_home variable to overwrite the home path.
Also, when creating oracle user in system it is not possible to add home attribute to specify a home (this is optional)

Old and not used anymore roles have not been corrected, the oracle_user_home variable is defined in orasw-meta defaults.
It should be considered to create top level defaults, as some roles depend on orahost_meta, and some on orasw-meta... This should be clarified. For now this fixes however most of the problems where oracle home is not under /home