### PR TITLE
orahost: added options to host_fs_layout

### DIFF
--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -314,7 +314,12 @@
   tags: hostfs
 
 - name: filesystem | Change permission on directories
-  file: path={{ item.1.mntp }} state=directory owner={{ oracle_user }} group={{ oracle_group }} mode=775
+  file:
+    path: "{{ item.1.mntp }}"
+    owner: "{{ item.1.owner | default(oracle_user) }}"
+    group: "{{ item.1.group | default(oracle_group) }}"
+    mode: "{{ item.1.mode | default('0775') }}"
+    state: directory
   with_subelements:
     - "{{ host_fs_layout }}"
     - filesystem


### PR DESCRIPTION
The `host_fs_layout` could be used to changed filesystems from OS itself.

Important:
Always set the owner, group and mode for filesystems, because the
defaults are oracle:oinstall and 0775.

Example:
```
host_fs_layout:
  - vgname: rootvg
    state: present
    filesystem:
      - {mntp: /tmp, lvname: tmplv, lvsize: 1200m, fstype: ext4, owner: root, group: root, mode: 1777}
    disk:
      - {device: /dev/sda, pvname: /dev/sda2}
```