### PR TITLE
fix: optional uid gid password

### DIFF
--- a/changelogs/fragments/107-optional_uid_gid_passwd.yaml
+++ b/changelogs/fragments/107-optional_uid_gid_passwd.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - uid/gid/passwd attribute in oracle_users/grid_users/oracle_groups is now optional (#107)

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -107,7 +107,10 @@
 #    when: configure_etc_hosts and ansible_default_ipv4.address is defined
 
 - name: User | Add group(s)
-  ansible.builtin.group: name={{ item.group }} gid={{ item.gid }} state=present
+  ansible.builtin.group:
+    name: "{{ item.group }}"
+    gid: "{{ item.gid | default(omit) }}"
+    state: present
   with_items: "{{ oracle_groups }}"
   tags:
     - group
@@ -117,12 +120,12 @@
     name: "{{ item.username }}"
     group: "{{ item.primgroup }}"
     groups: "{{ item.othergroups }}"
-    uid: "{{ item.uid }}"
+    uid: "{{ item.uid | default(omit) }}"
     home: "{{ item.home | default(omit) }}"
     generate_ssh_key: true
     append: true
     state: present
-    password: "{{ item.passwd }}"
+    password: "{{ item.passwd | default(omit) }}"
   with_items: "{{ oracle_users }}"
   tags:
     - user
@@ -132,12 +135,12 @@
     name: "{{ item.username }}"
     group: "{{ item.primgroup }}"
     groups: "{{ item.othergroups }}"
-    uid: "{{ item.uid }}"
+    uid: "{{ item.uid | default(omit) }}"
     home: "{{ item.home | default(omit) }}"
     generate_ssh_key: true
     append: true
     state: present
-    password: "{{ item.passwd }}"
+    password: "{{ item.passwd | default(omit) }}"
   when: role_separation
   with_items: "{{ grid_users }}"
   tags:


### PR DESCRIPTION
With this PR the uid and gid attributes in oracle_users / oracle_groups are optional. This will allow adding sudo or ssh keys to systems already having users/groups provisioned without the need of entering real system uid/gid values back into inventory.
In addition the password attribute in oracle_users is also made optional, as not to forcefully alter passwords of already present users.

Hint: For skipping the entire user/group/sudo/ssh_keys parts completely either use skip_tags, or just set oracle_users and oracle_groups to empty lists ([])