### PR TITLE
bugfix: host_fs_layout needed disk even if configure_host_disks==false

### DIFF
--- a/changelogs/fragments/108-host_fs_layout.yaml
+++ b/changelogs/fragments/108-host_fs_layout.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'does not require host_fs_layout to have "disks" attribute when "configure_host_disks==false" (#108)'

--- a/roles/orahost/tasks/main.yml
+++ b/roles/orahost/tasks/main.yml
@@ -261,7 +261,9 @@
   with_subelements:
     - "{{ host_fs_layout }}"
     - disk
-  when: configure_host_disks and item.1.device != item.1.pvname
+    - flags:
+      skip_missing: true
+  when: configure_host_disks and item.1 is defined and item.1.device != item.1.pvname
   tags: hostfs
 
 - name: filesystem | Create vg


### PR DESCRIPTION
This PR allows to just set configure_host_disks false and still be able to chown/chmod mountpoints specified by filesystem attributes in host_fs_layout without the need of adding empty array "disks" attribute there, to satisfy with_subelements task (that would be ignored anyway by configure_host_disks in when condition).