### PR TITLE
pass container and container_data parameters to modules

### DIFF
--- a/roles/oradb_manage_grants/tasks/main.yml
+++ b/roles/oradb_manage_grants/tasks/main.yml
@@ -13,6 +13,7 @@
     service_name={{ db_service_name }}
     user={{ db_user }}
     password={{ db_password_cdb }}
+    container={{ item.1.container | default(omit) }}
     mode={{ db_mode }}
   with_subelements:
     - "{{ oracle_databases }}"
@@ -72,6 +73,7 @@
     service_name={{ db_service_name }}
     user={{ db_user }}
     password={{ db_password_cdb }}
+    container={{ item.1.container | default(omit) }}
     mode={{ db_mode }}
   with_subelements:
     - "{{ oracle_databases }}"

--- a/roles/oradb_manage_users/tasks/main.yml
+++ b/roles/oradb_manage_users/tasks/main.yml
@@ -17,6 +17,7 @@
     default_tablespace={{ item.1.default_tablespace | default (omit) }}
     default_temp_tablespace={{ item.1.default_temp_tablespace | default (omit) }}
     container={{ item.1.container | default(omit) }}
+    container_data={{ item.1.container_data | default(omit) }}
     update_password={{ item.1.update_password | default(omit) }}
     authentication_type={{ item.1.authentication_type | default(omit) }}
     grants={{ item.1.grants | default (omit) }}


### PR DESCRIPTION
Pass ``container`` parameter to ``oracle_grants`` module and ``container_data`` to ``oracle_user`` module.
Modules already support it.