### PR TITLE
Add option to ignore_errors on oradb_facts role

### DIFF
--- a/roles/oradb_facts/defaults/main.yml
+++ b/roles/oradb_facts/defaults/main.yml
@@ -3,3 +3,9 @@
 # The dbuser for connection to database.
 # @end
 oradb_facts_db_user: sys
+
+# @var oradb_facts_ignore_errors:description: >
+# Allows to set `ignore_errors` when running `oracle_facts` module against not running or not yet installed database. By default no ignore_errors is used.
+# When using, use this as role parameter and not inventory variable so that when called via dependency no ignore_errors is applied.
+# @end
+# oradb_facts_ignore_errors: true

--- a/roles/oradb_facts/tasks/db_facts.yml
+++ b/roles/oradb_facts/tasks/db_facts.yml
@@ -9,6 +9,7 @@
     password: "{{ _db_password_cdb }}"
     mode: sysdba
   environment: "{{ _oracle_env }}"
+  ignore_errors: "{{ oradb_facts_ignore_erros | default(omit) }}"
   register: dbfactsreg
   vars:
     # set db_user for _db_password_cdb


### PR DESCRIPTION
This PR adds a possibility to ignore errors on `oradb_facts` role for `oracle_facts` module call.
It can happen that one database is not yet installed or (worse) is just not started and because of that `oradb_facts` caused the entire playbook to fail at this step.

As much as I do not recommend ignoring any failed tasks, it might come to a point, where it is really a must have.
Due to current implementation via `ansible.builtin.include_tasks: db_facts.yml` it is at the moment technically not possible to specify ignore_errors just for one database of a host nor to provide only a subset of databases to check the facts for. Entire role can get `ignore_errors: true`, but then no database after the first error will be checked.